### PR TITLE
[lsp] Basic "language server protocol" server.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_install:
   - opam update
   - opam switch "$OCAML_VERSION"
   - eval $(opam env)
-  - opam install dune menhir bindlib.5.0.0 timed.1.0 earley.1.1.0 earley-ocaml.1.1.0
+  - opam install dune menhir bindlib.5.0.0 timed.1.0 earley.1.1.0 earley-ocaml.1.1.0 yojson cmdliner
 
 script:
   - make

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -174,3 +174,18 @@ endif
 opam-release:
 	dune-release distrib
 	dune-release opam pkg
+
+OPAM_REPO=/home/egallego/external/coq/opam-deducteam
+OPAM_LP_VER=$(shell dune-release log -t)
+# Prior to build:
+# - dune-release log edit && dune-release tag commit [or edit by yourself]
+# - dune-release tag                                 [or git tag]
+lsp_release:
+	rm -rf _build
+	dune-release distrib
+	dune-release publish distrib
+#	dune-release opam pkg -p lambdapi
+	dune-release opam pkg -p lambdapi-lsp
+	# cp -a _build/lambdapi.$(OPAM_LP_VER) $(OPAM_REPO)/packages/lambdapi/
+	cp -a _build/lambdapi-lsp.$(OPAM_LP_VER) $(OPAM_REPO)/packages/lambdapi-lsp/
+	cd $(OPAM_REPO) && git add -A && git commit -a -m "[lambdapi-lsp] new version $(OPAM_LP_VER)"

--- a/lambdapi-lsp.opam
+++ b/lambdapi-lsp.opam
@@ -1,0 +1,23 @@
+synopsis: "Implementation of the λΠ-calculus modulo rewriting"
+description:
+"""
+Lambdapi is an implementation of the λΠ-calculus modulo rewriting, that is
+mostly compatible with Dedukti (https://github.com/Deducteam/Dedukti).
+"""
+opam-version: "2.0"
+maintainer: "dedukti-dev@inria.fr"
+authors: "Emilio Jesús Gallego Arias <e@x80.org>"
+homepage: "https://github.com/rlepigre/lambdapi"
+bug-reports: "https://github.com/rlepigre/lambdapi/issues"
+dev-repo: "https://github.com/ejgallego/lambdapi.git"
+license: "CeCILL"
+
+depends: [
+  "ocaml"       {         >= "4.04.0" }
+  "dune"        { build & >= "1.3.0"  }
+  "lambdapi"  # { = version }
+  "yojson"
+  "cmdliner"
+]
+
+build: [ [ "dune" "build" "-p" name "-j" jobs ] ]

--- a/lambdapi.opam
+++ b/lambdapi.opam
@@ -25,4 +25,4 @@ depends: [
   "timed"        { >= "1.0"   }
 ]
 
-build: [ [ "jbuilder" "build" "-p" name "-j" jobs ] ]
+build: [ [ "dune" "build" "-p" name "-j" jobs ] ]

--- a/lp-lsp/CHANGES.md
+++ b/lp-lsp/CHANGES.md
@@ -1,0 +1,79 @@
+0.0.9.0
+-------
+
+- First standalone release; code is the same, but we don't build a
+  lambdapi package anymore.
+
+0.0.8.7
+-------
+- [lambdapi] Rebase against 98fbf803959579dcb1e41989a33797aef10fac9b
+- [core] Preliminary document type.
+- [hover] Add basic hover protocol support.
+
+0.0.8.6
+-------
+- [goals] Better information for display of goals in focus.
+
+0.0.8.5
+-------
+- [improv] Try to refine symbol type.
+
+0.0.8.4
+-------
+- [fix] Send correct `documentSymbol` `Location` object in response.
+
+0.0.8.3
+-----
+- [fix] Get `documentSymbol`s at the completed document state.
+
+0.0.8.2
+-----
+- Fix location info for new LP API.
+
+0.0.8.1
+-----
+- Rebase against new `pureinterface` branch.
+
+0.0.8
+-----
+- Preliminary support for `documentSymbol` request.
+
+0.0.7.2
+-----
+- Support for emacs' [eglot](https://github.com/joaotavora/eglot).
+
+0.0.7.1
+-----
+- Send hypothesis name and type separately.
+
+0.0.7
+-----
+- Send structured goals in diagnostics.
+
+0.0.6
+-----
+- Tweaked changelog.
+- Better OPAM makefile script.
+- Fix problem with `exit` call.
+
+0.0.5
+-----
+- Updated lambdapi to pureinterface branch
+- Fixed a few json object types bugs.
+- Send goal information in simple form.
+
+0.0.4
+-----
+- Fixed shutdown and exit calls
+
+0.0.3
+-----
+- Improved protocol support by Ismail
+
+0.0.2
+-----
+- Minor tweaks to packaging
+
+0.0.1
+-----
+- Initial release of LambdaPI to OPAM

--- a/lp-lsp/README.md
+++ b/lp-lsp/README.md
@@ -1,0 +1,53 @@
+## Protocol For Logical Formalizations
+
+This directory contains a prototype language server for the λΠ logical
+framework. At this stage, this is a very experimental prototype, use
+with care.
+
+To build:
+
+```
+opam install dune cmdliner yojson
+dune build
+```
+
+The resulting binary will be in `../_build/install/default/bin/lp-lsp`
+
+## Using with Emacs
+
+`lp-lsp` will work out of the box with emacs and eglot, to do so,
+install [eglot](https://github.com/joaotavora/eglot) [using `M-x
+package-install eglot RET` should work], then do `M-x eglot` and
+specify as a server `lp-lsp --std`.
+
+`eglot` doesn't support the extended protocol information sent by
+`lp-lsp` yet.
+
+## Development TODO
+
+### Phase 1: Basic document checking.
+
++ Re-implement document traversal.
++ Incremental checking.
+
+### Phase 2: Basic interactive proofs
+
+The goal of this phase is to add support for basic interaction with
+λΠ, this will done by means of a query language that will support
+goals, search, typeof, etc...
+
+### Phase 3: Advanced UI support
+
+In this phase we will provide some more advanced features for large
+scale proof editing. In particular:
+
++ holes / incomplete proofs
++ diff management
+
+## Structure of the server.
+
+The server is split in 3 components:
+
+- `Lsp_*`: Files dealing with LSP structures.
+- `Lp_doc`: Document model for LP documents.
+- `Lp_lsp`: Main server, command handlers.

--- a/lp-lsp/dune
+++ b/lp-lsp/dune
@@ -1,0 +1,21 @@
+; (library
+;  ((name lptop_extra)
+;   (public_name lptop.extra)
+;   (modules (:standard \ (lpargs lptop lplsp)))
+;   (preprocess (per_module
+;                ((pps (ppx_sexp_conv ppx_deriving_yojson)) (feedback lpapi lpdoc))))
+;   (libraries (lambdapi.core sexplib yojson ppx_deriving_yojson.runtime))))
+
+; (executable
+;  ((name lptop)
+;   (public_name lptop)
+;   (modules (lpargs lptop))
+;   (package lptop)
+;   (libraries (lptop.extra cmdliner))))
+
+(executable
+ (name lp_lsp)
+ (public_name lp-lsp)
+ (modules lsp_base lsp_io lp_doc lp_lsp)
+ (package lambdapi-lsp)
+ (libraries lambdapi.core yojson cmdliner))

--- a/lp-lsp/lp_doc.ml
+++ b/lp-lsp/lp_doc.ml
@@ -1,0 +1,81 @@
+(************************************************************************)
+(* The λΠ-modulo Interactive Proof Assistant                            *)
+(************************************************************************)
+
+(************************************************************************)
+(* λΠ-modulo serialization arguments                                    *)
+(* Copyright 2018 MINES ParisTech -- Dual License LGPL 2.1 / GPL3+      *)
+(* Written by: Emilio J. Gallego Arias                                  *)
+(************************************************************************)
+(* Status: Very Experimental                                            *)
+(************************************************************************)
+
+module LSP = Lsp_base
+
+type ast = Parser.p_cmd Pos.loc
+
+type doc_node = {
+  ast  : ast;
+  exec : bool;
+}
+
+(* Private. A doc is a list of nodes for now. The first element in
+   the list is assumed to be the tip of the document. The initial
+   document is the empty list.
+*)
+type doc = {
+  uri : string;
+  version: int;
+  text : string;
+  root : Pure.state;
+  nodes : doc_node list;
+}
+
+let mk_error ~doc pos msg =
+  LSP.mk_diagnostics ~uri:doc.uri ~version:doc.version [pos, 1, msg, None]
+
+let parse_text contents =
+  let open Earley in
+  parse_string Parser.cmd_list Parser.blank contents
+
+(* XXX: Imperative problem *)
+let process_cmd _file (st,dg) node =
+  let open Pos  in
+  let open Pure in
+  (* let open Timed in *)
+  (* XXX: Capture output *)
+  (* Console.out_fmt := lp_fmt;
+   * Console.err_fmt := lp_fmt; *)
+  match handle_command st node with
+  | OK st ->
+    (* let ok_diag = node.pos, 4, "OK", !Proofs.theorem in *)
+    let ok_diag = node.pos, 4, "OK", None in
+    st, ok_diag :: dg
+  | Error (_loc, msg) ->
+    st, (node.pos, 1, msg, None) :: dg
+
+let new_doc ~uri ~version ~text =
+  { uri;
+    text;
+    version;
+    root = Pure.initial_state [uri];
+    nodes = [];
+  }
+
+(* XXX: Save on close. *)
+let close_doc _modname = ()
+
+let check_text ~doc =
+  let uri, version = doc.uri, doc.version in
+  try
+    let doc_spans = parse_text doc.text in
+    let st, diag = List.fold_left (process_cmd uri) (doc.root,[]) doc_spans in
+    st, LSP.mk_diagnostics ~uri ~version @@ List.fold_left (fun acc (pos,lvl,msg,goal) ->
+        match pos with
+        | None     -> acc
+        | Some pos -> (pos,lvl,msg,goal) :: acc
+      ) [] diag
+  with
+  | Earley.Parse_error(buf,pos) ->
+    let loc = Pos.locate buf pos buf pos in
+    doc.root, mk_error ~doc loc "Parse error."

--- a/lp-lsp/lp_lsp.ml
+++ b/lp-lsp/lp_lsp.ml
@@ -1,0 +1,269 @@
+(************************************************************************)
+(* The λΠ-modulo Interactive Proof Assistant                            *)
+(************************************************************************)
+
+(************************************************************************)
+(* λΠ-modulo serialization Toplevel                                     *)
+(* Copyright 2018 MINES ParisTech -- Dual License LGPL 2.1 / GPL3+      *)
+(* Written by: Emilio J. Gallego Arias                                  *)
+(************************************************************************)
+(* Status: Very Experimental                                            *)
+(************************************************************************)
+
+module F = Format
+module J = Yojson.Basic
+module U = Yojson.Basic.Util
+
+(* OCaml 4.04 compat *)
+module Hashtbl = struct
+  include Hashtbl
+  let find_opt n d = try Some Hashtbl.(find n d) with | Not_found -> None
+end
+
+module List = struct
+  include List
+  let assoc_opt n d = try Some List.(assoc n d) with | Not_found -> None
+end
+
+let    int_field name dict = U.to_int    List.(assoc name dict)
+let   dict_field name dict = U.to_assoc  List.(assoc name dict)
+let   list_field name dict = U.to_list   List.(assoc name dict)
+let string_field name dict = U.to_string List.(assoc name dict)
+
+(* Conditionals *)
+let option_empty x = match x with | None -> true | Some _ -> false
+let option_cata f x d = match x with | None -> d | Some x -> f x
+let option_default x d = match x with | None -> d | Some x -> x
+
+let oint_field  name dict = option_cata U.to_int List.(assoc_opt name dict) 0
+let odict_field name dict = option_default U.(to_option to_assoc (option_default List.(assoc_opt name dict) `Null)) []
+
+module LIO = Lsp_io
+module LSP = Lsp_base
+
+(* Request Handling: The client expects a reply *)
+let do_initialize ofmt ~id _params =
+  let msg = LSP.mk_reply ~id ~result:(
+      `Assoc ["capabilities",
+       `Assoc [
+          "textDocumentSync", `Int 1
+        ; "documentSymbolProvider", `Bool true
+        ; "hoverProvider", `Bool true
+        ; "codeActionProvider", `Bool false
+        ]]) in
+  LIO.send_json ofmt msg
+
+let do_shutdown ofmt ~id =
+  let msg = LSP.mk_reply ~id ~result:`Null in
+  LIO.send_json ofmt msg
+
+let doc_table : (string, _) Hashtbl.t = Hashtbl.create 39
+let completed_table : (string, Pure.state) Hashtbl.t = Hashtbl.create 39
+
+(* Notification handling; reply is optional / asynchronous *)
+let do_check_text ofmt ~doc =
+  let final_st, diags = Lp_doc.check_text ~doc in
+  Hashtbl.replace completed_table doc.uri final_st;
+  LIO.send_json ofmt @@ diags
+
+let do_change ofmt ~doc change =
+  let open Lp_doc in
+  LIO.log_error "checking file" (doc.uri ^ " / version: " ^ (string_of_int doc.version));
+  let doc = { doc with text = string_field "text" change; } in
+  do_check_text ofmt ~doc
+
+let do_open ofmt params =
+  let document = dict_field "textDocument" params in
+  let uri, version, text =
+    string_field "uri" document,
+    int_field "version" document,
+    string_field "text" document in
+  let doc = Lp_doc.new_doc ~uri ~text ~version in
+  begin match Hashtbl.find_opt doc_table uri with
+    | None -> ()
+    | Some _ -> LIO.log_error "do_open" ("file " ^ uri ^ " not properly closed by client")
+  end;
+  Hashtbl.add doc_table uri doc;
+  do_check_text ofmt ~doc
+
+let do_change ofmt params =
+  let document = dict_field "textDocument" params in
+  let uri, version  =
+    string_field "uri" document,
+    int_field "version" document in
+  let changes = List.map U.to_assoc @@ list_field "contentChanges" params in
+  let doc = Hashtbl.find doc_table uri in
+  let doc = { doc with Lp_doc.version; } in
+  List.iter (do_change ofmt ~doc) changes
+
+let do_close _ofmt params =
+  let document = dict_field "textDocument" params in
+  let doc_file = string_field "uri" document in
+  Hashtbl.remove doc_table doc_file
+
+let grab_doc params =
+  let document = dict_field "textDocument" params in
+  let doc_file = string_field "uri" document in
+  let start_doc, end_doc = Hashtbl.(find doc_table doc_file, find completed_table doc_file) in
+  doc_file, start_doc, end_doc
+
+let mk_syminfo file (name, _path, kind, pos) : J.json =
+  `Assoc [
+    "name", `String name;
+    "kind", `Int kind;            (* function *)
+    "location", `Assoc [
+                    "uri", `String file
+                  ; "range", LSP.mk_range pos
+                  ]
+  ]
+
+let kind_of_type tm =
+  let open Terms in
+  let open Timed in
+  let is_undef = option_empty !(tm.sym_def) && List.length !(tm.sym_rules) = 0 in
+  match !(tm.sym_type) with
+  | Vari _ ->
+    13                         (* Variable *)
+  | Type | Kind | Symb _ | _ when is_undef ->
+    14                         (* Constant *)
+  | _ ->
+    12                         (* Function *)
+
+let do_symbols ofmt ~id params =
+  let open Timed in
+  let file, _, final_st = grab_doc params in
+  let sym = Pure.in_state final_st (fun () -> !(Sign.(current_sign ()).symbols)) () in
+  let sym = Extra.StrMap.fold (fun _ (s,p) l ->
+      let open Terms in
+      (* LIO.log_error "sym" (s.sym_name ^ " | " ^ Format.asprintf "%a" pp_term !(s.sym_type)); *)
+      option_cata (fun p -> mk_syminfo file
+                      (s.sym_name, s.sym_path, kind_of_type s, p) :: l) p l) sym [] in
+  let msg = LSP.mk_reply ~id ~result:(`List sym) in
+  LIO.send_json ofmt msg
+
+let get_docTextPosition params =
+  let document = dict_field "textDocument" params in
+  let file = string_field "uri" document in
+  let pos = dict_field "position" params in
+  let line, character = int_field "line" pos, int_field "character" pos in
+  file, line, character
+
+let do_hover ofmt ~id params =
+  let _ = get_docTextPosition params in
+  let result = `Assoc [ "contents", `String "hover XXX"] in
+  let msg = LSP.mk_reply ~id ~result in
+  LIO.send_json ofmt msg
+
+(* XXX: We could split requests and notifications but with the OCaml
+   theading model there is not a lot of difference yet; something to
+   think for the future. *)
+let dispatch_message ofmt dict =
+  let id     = oint_field "id" dict in
+  let params = odict_field "params" dict in
+  match string_field "method" dict with
+  (* Requests *)
+  | "initialize" ->
+    do_initialize ofmt ~id params
+  | "shutdown" ->
+    do_shutdown ofmt ~id
+
+  (* Symbols in the document *)
+  | "textDocument/documentSymbol" ->
+    do_symbols ofmt ~id params
+
+  | "textDocument/hover" ->
+    do_hover ofmt ~id params
+
+  (* Notifications *)
+  | "textDocument/didOpen" ->
+    do_open ofmt params
+  | "textDocument/didChange" ->
+    do_change ofmt params
+  | "textDocument/didClose" ->
+    do_close ofmt params
+  | "exit" ->
+    exit 0
+
+  (* NOOPs *)
+  | "initialized"
+  | "workspace/didChangeWatchedFiles" ->
+    ()
+  | msg ->
+    LIO.log_error "no_handler" msg
+
+let process_input ofmt (com : J.json) =
+  try dispatch_message ofmt (U.to_assoc com)
+  with
+  | U.Type_error (msg, obj) ->
+    LIO.log_object msg obj
+  | exn ->
+    let bt = Printexc.get_backtrace () in
+    LIO.log_error "[BT]" bt;
+    LIO.log_error "process_input" (Printexc.to_string exn)
+
+let lsp_main log_file std =
+
+  Printexc.record_backtrace true;
+  LSP.std_protocol := std;
+
+  let oc = F.std_formatter in
+
+  let debug_oc = open_out log_file in
+  LIO.debug_fmt := F.formatter_of_out_channel debug_oc;
+
+  (* XXX: Capture better / per sentence. *)
+  let lp_oc = open_out "log-lp.txt" in
+  let lp_fmt = F.formatter_of_out_channel lp_oc in
+  Console.out_fmt := lp_fmt;
+  Console.err_fmt := lp_fmt;
+  (* Console.verbose := 4; *)
+
+  let rec loop () =
+    let com = LIO.read_request stdin in
+    LIO.log_object "read" com;
+    process_input oc com;
+    F.pp_print_flush lp_fmt (); flush lp_oc;
+    loop ()
+  in
+  try loop ()
+  with exn ->
+    let bt = Printexc.get_backtrace () in
+    LIO.log_error "[fatal error]" Printexc.(to_string exn);
+    LIO.log_error "[BT]" bt;
+    F.pp_print_flush !LIO.debug_fmt ();
+    flush_all ();
+    close_out debug_oc;
+    close_out lp_oc
+
+open Cmdliner
+
+(* let bt =
+ *   let doc = "Enable backtraces" in
+ *   Arg.(value & flag & info ["bt"] ~doc) *)
+
+let log_file =
+  let doc = "Log to $(docv)" in
+  Arg.(value & opt string "log-lsp.txt" & info ["log_file"] ~docv:"FILE" ~doc)
+
+let std =
+  let doc = "Restrict to standard LSP protocol" in
+  Arg.(value & flag & info ["std"] ~doc)
+
+let lsp_cmd =
+  let doc = "LP LSP Toplevel" in
+  let man = [
+    `S "DESCRIPTION";
+    `P "Experimental LP Toplevel with LSP support";
+    `S "USAGE";
+    `P "See the documentation on the project's webpage for more information"
+  ]
+  in
+  Term.(const lsp_main $ log_file $ std),
+  Term.info "lp-lsp" ~version:"0.0" ~doc ~man
+
+let main () =
+  match Term.eval lsp_cmd with
+  | `Error _ -> exit 1
+  | _        -> exit 0
+
+let _ = main ()

--- a/lp-lsp/lsp_base.ml
+++ b/lp-lsp/lsp_base.ml
@@ -1,0 +1,75 @@
+(************************************************************************)
+(* The λΠ-modulo Interactive Proof Assistant                            *)
+(************************************************************************)
+
+(************************************************************************)
+(* λΠ-modulo serialization Toplevel                                     *)
+(* Copyright 2018 MINES ParisTech -- Dual License LGPL 2.1 / GPL3+      *)
+(* Written by: Emilio J. Gallego Arias                                  *)
+(************************************************************************)
+(* Status: Very Experimental                                            *)
+(************************************************************************)
+
+(* Whether to send extended lsp messages *)
+let std_protocol = ref true
+
+module J = Yojson.Basic
+
+let mk_extra l = if !std_protocol then [] else l
+
+(* Ad-hoc parsing for file:///foo... *)
+let parse_uri str =
+  let l = String.length str - 7 in
+  String.(sub str 7 l)
+
+let mk_reply ~id ~result = `Assoc [ "jsonrpc", `String "2.0"; "id",     `Int id;   "result", result ]
+let mk_event m p   = `Assoc [ "jsonrpc", `String "2.0"; "method", `String m; "params", `Assoc p ]
+
+(*
+let json_of_goal g =
+  let pr_hyp (s,(_,t)) =
+    `Assoc ["hname", `String s;
+            "htype", `String (Format.asprintf "%a" Print.pp_term (Bindlib.unbox t))] in
+  let open Proofs in
+  let j_env = List.map pr_hyp g.g_hyps in
+  `Assoc [
+    "gid", `Int g.g_meta.meta_key
+  ; "hyps", `List j_env
+  ; "type", `String (Format.asprintf "%a" Print.pp_term g.g_type)]
+
+let json_of_thm thm =
+  let open Proofs in
+  match thm with
+  | None ->
+    `Null
+  | Some thm ->
+    `Assoc [
+      "goals", `List List.(map json_of_goal thm.t_goals)
+    ]
+*)
+
+let mk_range (p : Pos.pos) : J.json =
+  let open Pos in
+  let line1 = Input.line_num p.start_buf in
+  let line2 = Input.line_num p.end_buf   in
+  let col1  = Input.utf8_col_num p.start_buf p.start_pos in
+  let col2  = Input.utf8_col_num p.end_buf   p.end_pos   in
+  `Assoc ["start", `Assoc ["line", `Int (line1 - 1); "character", `Int col1];
+          "end",   `Assoc ["line", `Int (line2 - 1); "character", `Int col2]]
+
+(* let mk_diagnostic ((p : Pos.pos), (lvl : int), (msg : string), (thm : Proofs.theorem option)) : J.json = *)
+let mk_diagnostic ((p : Pos.pos), (lvl : int), (msg : string), (_thm : unit option)) : J.json =
+  (* let goal = json_of_thm thm in *)
+  let range = mk_range p in
+  `Assoc ((* mk_extra ["goal_info", goal] @ *)
+          ["range", range;
+           "severity", `Int lvl;
+           "message",  `String msg;
+          ])
+
+let mk_diagnostics ~uri ~version ld : J.json =
+  let extra = mk_extra ["version", `Int version] in
+  mk_event "textDocument/publishDiagnostics" @@
+    extra @
+    ["uri", `String uri;
+     "diagnostics", `List List.(map mk_diagnostic ld)]

--- a/lp-lsp/lsp_io.ml
+++ b/lp-lsp/lsp_io.ml
@@ -1,0 +1,56 @@
+(************************************************************************)
+(* The λΠ-modulo Interactive Proof Assistant                            *)
+(************************************************************************)
+
+(************************************************************************)
+(* λΠ-modulo serialization Toplevel                                     *)
+(* Copyright 2018 MINES ParisTech -- Dual License LGPL 2.1 / GPL3+      *)
+(* Written by: Emilio J. Gallego Arias                                  *)
+(************************************************************************)
+(* Status: Very Experimental                                            *)
+(************************************************************************)
+
+module F = Format
+module J = Yojson.Basic
+
+let debug_fmt = ref F.err_formatter
+
+let log_error hdr msg =
+  F.fprintf !debug_fmt "[%s]: @[%s@]@\n%!" hdr msg
+
+let log_object hdr obj =
+  F.fprintf !debug_fmt "[%s]: @[%a@]@\n%!" hdr J.(pretty_print ~std:false) obj
+
+exception ReadError of string
+
+let read_request ic =
+  let cl = input_line ic in
+  let sin = Scanf.Scanning.from_string cl in
+  try
+    let raw_obj =
+      Scanf.bscanf sin "Content-Length: %d\r" (fun size ->
+          let buf = Bytes.create size in
+          (* Consume the second \r\n *)
+          let _ = input_line ic in
+          really_input ic buf 0 size;
+          Bytes.to_string buf
+        ) in
+    J.from_string raw_obj
+  with
+  (* if the end of input is encountered while some more characters are needed to read the
+     current conversion specification. *)
+  | End_of_file ->
+    raise (ReadError "EOF")
+  (* if the input does not match the format. *)
+  | Scanf.Scan_failure msg
+  (* if a conversion to a number is not possible. *)
+  | Failure msg
+  (* if the format string is invalid. *)
+  | Invalid_argument msg ->
+    raise (ReadError msg)
+
+let send_json fmt obj =
+  log_object "send" obj;
+  let msg  = F.asprintf "%a" J.(pretty_print ~std:true) obj in
+  let size = String.length msg         in
+  F.fprintf fmt "Content-Length: %d\r\n\r\n%s%!" size msg


### PR DESCRIPTION
This is a first version on a language protocol server for LambdaPI
developed in the context of the internship of Ismail Lacheb by him,
Frédéric Blanqui, Emilio J. Gallego Arias, and Rodolphe Lepigre.

The server has been tested with Atom and Emacs, and supports the basic
operations. In previous versions it also supported an extension to
send proof goals as a diagnostic, but this is now currently disabled
due to upstream API issues.

Some notes:

- Lines in LSP start at 0 vs Dedukti where they start at 1.
- In addition to the base basic LSP protocol, we support
  the `documentSymbol` request.
- The server has an option to limit output to a standard LSP subset,
  see --help. This is needed by Emacs' eglot, which otherwise chokes.
