### PR TITLE
[dune] Configuration tweak following upstream recommendations.

### DIFF
--- a/dune
+++ b/dune
@@ -1,0 +1,4 @@
+; Add project-wide flags here.
+(env
+ (dev     (flags :standard))
+ (release (flags :standard)))

--- a/dune-workspace
+++ b/dune-workspace
@@ -1,8 +1,0 @@
-(lang dune 1.2)
-
-(context default)
-
-; Add custom flags here. Default developer profile is `dev`
-(env
- (dev     (flags :standard))
- (release (flags :standard)))


### PR DESCRIPTION
Dune upstream suggested that `dune-workspace` should be used for
developer-specific recommendations, thus, core settings are better
place in the root `dune` file.