### PR TITLE
[ci] Better testing in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,14 +10,15 @@ env:
   - OPAMJOBS="2"
   - OPAMYES="true"
   - OPAMVERBOSE="true"
+  - TEST_TARGETS="unit_tests real_tests"
   matrix:
-  - OCAML_VERSION=4.04.0
   - OCAML_VERSION=4.04.1
   - OCAML_VERSION=4.04.2
   - OCAML_VERSION=4.05.0
   - OCAML_VERSION=4.06.0
   - OCAML_VERSION=4.06.1
   - OCAML_VERSION=4.07.0
+  - OCAML_VERSION=4.07.0 TEST_TARGETS=opam-release EXTRA_OPAM=dune-release
 
 before_install:
   # Obtain and install opam locally.
@@ -28,11 +29,10 @@ before_install:
   - opam update
   - opam switch "$OCAML_VERSION"
   - eval $(opam env)
-  - opam install dune menhir bindlib.5.0.0 timed.1.0 earley.1.1.0 earley-ocaml.1.1.0 yojson cmdliner ppx_inline_test
+  - opam install dune menhir bindlib.5.0.0 timed.1.0 earley.1.1.0 earley-ocaml.1.1.0 yojson cmdliner ppx_inline_test $EXTRA_OPAM
 
 script:
-  - make
-  - make real_tests
+  - make $TEST_TARGETS
 
 notifications:
   email:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -10,6 +10,10 @@ all: bin
 bin:
 	@dune build
 
+.PHONY: unit_tests
+unit_tests:
+	@dune runtest
+
 .PHONY: doc
 doc:
 	@dune build @doc

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ with "bash on Windows".
 
 List of dependencies:
  - GNU make,
- - OCaml (at least 4.04.0),
+ - OCaml (at least 4.04.1),
  - Dune (at least 1.2.0),
  - odoc (for documentation only),
  - bindlib 5.0.0 (https://github.com/rlepigre/ocaml-bindlib),

--- a/lambdapi-lsp.opam
+++ b/lambdapi-lsp.opam
@@ -12,7 +12,7 @@ maintainer: "dedukti-dev@inria.fr"
 authors: "Emilio Jesús Gallego Arias <e@x80.org>"
 homepage: "https://github.com/rlepigre/lambdapi"
 bug-reports: "https://github.com/rlepigre/lambdapi/issues"
-dev-repo: "https://github.com/ejgallego/lambdapi.git"
+dev-repo: "git+https://github.com/rlepigre/lambdapi.git"
 license: "CeCILL"
 
 depends: [

--- a/src/pure.ml
+++ b/src/pure.ml
@@ -50,15 +50,24 @@ let handle_command : state -> Command.t Pos.loc -> result = fun (st,ss) cmd ->
 let get_symbols : state -> (Terms.sym * Pos.popt) StrMap.t = fun (st,_) ->
   Time.restore st; !(Sign.((current_sign ()).sign_symbols))
 
+(* Equality on *)
 let%test _ =
   let c = parse_text "foo.lp" "symbol const B : TYPE" in
   List.equal (fun x y -> Command.equal x.Pos.elt y.Pos.elt) c c
 
+(* Equality not *)
 let%test _ =
   let c = parse_text "foo.lp" "symbol const B : TYPE" in
   let d = parse_text "foo.lp" "symbol const C : TYPE" in
   not List.(equal (fun x y -> Command.equal x.Pos.elt y.Pos.elt) c d)
 
+(* Equality is not sensitive to whitespace *)
+let%test _ =
+  let c = parse_text "foo.lp" "symbol   const  B : TYPE" in
+  let d = parse_text "foo.lp" "  symbol const B :   TYPE " in
+  List.(equal (fun x y -> Command.equal x.Pos.elt y.Pos.elt) c d)
+
+(* More complex test stressing most commands *)
 let%test _ =
   let c = parse_text "foo.lp" "
 symbol const B : TYPE


### PR DESCRIPTION
We run the unit tests and add an opam-building job.

`dune-release` will always run the unit tests, but we also run them in
the regular builds just in case.

We tweak a few unit tests on the way. Note, support for 4.04.0 had to
be dropped due to what it looks like an incompatibility with certain
ppx. IMHO that is not so serious as 4.04 users should be in 4.04.2 [or
even better in 4.05].