### PR TITLE
Better apply tactic (following an attempt by @FranckS).

### DIFF
--- a/examples/apply.lp
+++ b/examples/apply.lp
@@ -1,0 +1,19 @@
+symbol const A : TYPE
+symbol const B : TYPE
+
+theorem test1 : (A ⇒ B) ⇒ A ⇒ B
+proof
+  intro h1 h2
+  apply h1
+  apply h2
+qed
+
+symbol const C : TYPE
+
+theorem test2 : (A ⇒ B ⇒ C) ⇒ A ⇒ B ⇒ C
+proof
+  intro h1 h2 h3
+  apply h1
+  apply h2
+  apply h3
+qed

--- a/src/basics.ml
+++ b/src/basics.ml
@@ -10,6 +10,13 @@ open Terms
 let to_tvars : term array -> tvar array =
   Array.map (function Vari(x) -> x | _ -> assert false)
 
+(** [count_products a] returns the number of consecutive products at the  head
+    of the term [a]. *)
+let rec count_products : term -> int = fun t ->
+  match unfold t with
+  | Prod(_,b) -> 1 + count_products (snd (Bindlib.unbind b))
+  | _         -> 0
+
 (** [get_args t] decomposes the {!type:term} [t] into a pair [(h,args)], where
     [h] is the head term of [t] and [args] is the list of arguments applied to
     [h] in [t]. The returned [h] cannot be an {!constr:Appl} node. *)


### PR DESCRIPTION
Correct implementation of the apply tactic proposed by @FranckS in #106 / #112.

**Note:** the semantics of the `Wild` constructor in type `Terms.term` is NOT that of a metavariable. The documentation clearly states that it represents a wildcard in a pattern. This constructor should never appear in terms.